### PR TITLE
Pin Adafruit_MAX31865 to 1.1.0

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -29,7 +29,7 @@ lib_deps =
   TMCStepper@>=0.6.2,<1.0.0
   Adafruit NeoPixel
   U8glib-HAL=https://github.com/MarlinFirmware/U8glib-HAL/archive/bugfix.zip
-  Adafruit_MAX31865=https://github.com/adafruit/Adafruit_MAX31865/archive/master.zip
+  Adafruit_MAX31865=https://github.com/adafruit/Adafruit_MAX31865/archive/1.1.0.zip
   LiquidTWI2=https://github.com/lincomatic/LiquidTWI2/archive/master.zip
   Arduino-L6470=https://github.com/ameyer/Arduino-L6470/archive/0.8.0.zip
   SailfishLCD=https://github.com/mikeshub/SailfishLCD/archive/master.zip


### PR DESCRIPTION
Not sure if you hit this or not, but I can't compile 2.0.x branch without this.

This is fixed on bugfix branch, but this is a workaround
until the bugfix branch is merged into 2.0.x.

See: https://github.com/MarlinFirmware/Marlin/issues/18081